### PR TITLE
Fix processing of template nodes

### DIFF
--- a/test/targeting.js
+++ b/test/targeting.js
@@ -67,4 +67,20 @@ describe("Targeting and replacement", async () => {
     assertEqual(div.innerHTML, 'Success!')
     assertTruthy(style)
   })
+
+  it('replaces itself with an HTML element which in turn functions as expected', async () => {
+    fetchMock.get("/test", '<button id=response target="_this" action="/test2">Success!</div>')
+    fetchMock.get("/test2", 'plaintext')
+    const div = make(`
+      <div><button id=test action="/test" target="_this">HTML</button></div>
+    `)
+    const button = byId('test')
+    button.click()
+    await fetchMock.flush(true)
+    const response = byId('response')
+    assertEqual(response.innerHTML, 'Success!')
+    response.click();
+    await fetchMock.flush(true)
+    assertEqual(div.innerHTML, 'plaintext')
+  })
 })

--- a/triptych.js
+++ b/triptych.js
@@ -81,7 +81,7 @@ function ajax(rawUrl, method, formData, target) {
     if (targetElement) {
       const template = document.createElement('template')
       template.innerHTML = responseText
-      processNode(template)
+      processNode(template.content)
 
       // @ts-ignore - all the targets are going to be Elements
       targetElement.replaceWith(template.content)


### PR DESCRIPTION
The contents of template elements aren't technically the children of that template element. So `template.querySelectorAll('button[action]')` would always return an empty nodelist, however `template.content.querySelectorAll('button[action]')` would return buttons that are part of the template's contents.

I discovered this when working with two buttons like:

```
<button target="_this" action="/feeds/subscribe/1" method="PUT">Subscribe</button>
<button target="_this" action="/feeds/subscribe/1" method="DELETE">Unsubscribe</button>
```

Where the respective actions return the opposite button. Only the first click worked.

Looking into it a bit deeper in the spec I found that in fact [the content model of the template node is `nothing`:](https://html.spec.whatwg.org/multipage/scripting.html#the-template-element)

> It is also possible, as a result of DOM manipulation, for a [template](https://html.spec.whatwg.org/multipage/scripting.html#the-template-element) element to contain [Text](https://dom.spec.whatwg.org/#interface-text) nodes and element nodes; however, having any is a violation of the [template](https://html.spec.whatwg.org/multipage/scripting.html#the-template-element) element's content model, since its content model is defined as [nothing](https://html.spec.whatwg.org/multipage/dom.html#concept-content-nothing).

A little example you could run in a browser console:
```
const template = document.createElement('template');
template.innerHTML = '<button action="POST" target="_this">Click Me!</button';
console.log(template.querySelectorAll('button[action]'));
console.log(template.content.querySelectorAll('button[action]'));
```

I added a test and confirmed that it passes with this change and fails without it.

Happy to do this a different way if you think there's a better solution. Just noticed this and wanted to contribute back. Love the proposal and it's working great for a small site that doesn't need everything that htmx brings.