### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=id">Bahasa Indonesia</a>
+      </div>
+    </div>
+  </details>
+</div>
+
 # Triptych - New Attributes for HTML
 
 [Triptych](https://alexanderpetros.com/triptych) is a polyfill for three small HTML proposals:


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links : 
- [English](https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=en)
- [简体中文](https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=alexpetros&project=triptych&lang=ko)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962" />

If this was not your expection, please close this PR. Thank you! 🙌
