### PR TITLE
Fix reference of cancel button in button actions.

### DIFF
--- a/www/button-actions.html
+++ b/www/button-actions.html
@@ -352,8 +352,8 @@ Recall the <section-ref ref="multi-action-pages">Multi-Action Pages</section-ref
 <p>
 In a multi-page website, both of these actions should be page navigations.
 The "submit" button performs a page navigation with form submissions.
-The "close" button should be able to perform a page navigation that <em>doesn't</em> submit a form (since it was cancelled).
-A button enforces that the close action always happens in this browsing context, while a hyperlink does not.
+The "cancel" button should be able to perform a page navigation that <em>doesn't</em> submit a form (since it was cancelled).
+A button enforces that the cancel action always happens in this browsing context, while a hyperlink does not.
 
 <p>
 This proposal does not take a stand on exactly when a button is appropriate versus a hyperlink.


### PR DESCRIPTION
I was reading through the proposals and think there may be a mistake in this section. The code names the button "cancel", but the description calls it a "close" button.